### PR TITLE
Add Tox Github action to octopipes repo

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,24 @@
+name: tox
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  tox:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.10']
+        os: ['ubuntu-latest']
+
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: install tox
+      run: pip install --upgrade tox virtualenv
+    - name: run tox
+      run: tox -e py


### PR DESCRIPTION
Adding tox job to run tests on `py3.10` and `py3.11` on each push.