### PR TITLE
Add `pytorch` hook to free memory

### DIFF
--- a/octopipes/hooks/pytorch_hooks.py
+++ b/octopipes/hooks/pytorch_hooks.py
@@ -1,0 +1,10 @@
+import gc
+
+import torch
+
+
+def free_memory(wf_iter):
+    del wf_iter
+    torch.cuda.empty_cache()
+    gc.collect()
+

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setup(
         'cmap'
     ],
     extras_require={
-        'opencv': ['opencv-python']
+        'opencv': ['opencv-python'],
+        'pytorch': ['torch', 'torchvision']
     },
     classifiers=[
         'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
Adds a `free_memory` hook to free cuda memory after running a model with `pytorch`