### PR TITLE
[feat] Add multiple argument process through the `requires`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ wf_iter.recap()
 wf = Workflow('wf_name', metadata={'thresh': 0.4}).add(lambda x: x ** 2)
 ```
 
-### Output handlers
+#### Output handlers
 When adding a new step that outputs a certain results that you want to be processed in a particular way, you can pass a class that
 implements the `OutputHandler` interface.
 
@@ -86,6 +86,25 @@ Handlers are added this way. If None were supplied, `DefaultHandler` is used. *(
 ```python
 wf = Workflow('wf_name').add(some_func, some_handler)
 ```
+
+#### Steps with multiple inputs
+The `add` method that takes an optional `requires` flag in cases a step needs additional inputs from previous steps
+other than the one strictly before it. The flag is a series of comma separated step number like (`0`, `0,1,2`) where 0 is the first input of the workflow and 1 the output of the first step.
+
+To understand this flag, let's suppose that we have such a requirement:
+```
+(input) -> p1 -> p2 -> p3
+```
+Now let's say p3 not only requires the output of `p2` but also the first `input`. In this case when defining your
+workflow you can specify a `requires` flag `requires='0'` that will inject `input` as the second argument to your
+process.
+
+```python
+.add(lambda p2, input: some_calculation(input, p2), requires='0')
+```
+
+Note that the order of the steps in the `requires` flag is retained when injecting the arguments, and the previous
+step of the workflow is ignored in case it is present in `requires` as it is automatically injected by default.
 
 ### AggregateFlows
 `AggregateFlows` allows running **multiple** workflows on the same input. This is usually used when either benchmarking multiple

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name='octopipes',
-    version='0.1.0',
+    version='0.1.0-1',
     description='Pipeline library for AI workflows.',
     author='Octomiro',
     author_email='contact@octomiro.ai',

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -12,3 +12,27 @@ def test_workflow():
 
     wf_iter.recap()
     wf_iter.freeze()
+
+
+def test_process_requires():
+    wf = Workflow('test_wf_1')\
+            .add(lambda x: x + 1)\
+            .add(lambda x, y: x - y, requires='0')
+
+    wf_iter = wf(1)
+    for _ in wf_iter:
+        pass
+    
+    assert wf_iter.outputs[-1] == 1
+        
+
+    wf = Workflow('test_wf_1')\
+            .add(lambda x: x + 'step1')\
+            .add(lambda x: x + 'step2')\
+            .add(lambda x, y, z: x + y + z, requires='0,1')
+
+    wf_iter = wf('input')
+    for _ in wf_iter:
+        pass
+    
+    assert wf_iter.outputs[-1] == 'inputstep1step2inputinputstep1'


### PR DESCRIPTION
This PR adds the possibility for a process to require the result of previous steps what are not directly before it.

let's say that a process (step 2) not only requires the result of the previous step but also the initial input to the workflow. With this PR, we can inject the needed results through the `requires` default argument when adding a step with the `add` method.

In this case the second step of the workflow requires the initial input of the workflow:
```Python
wf = Workflow('name').add(some_processing).add(lambda x y: x + y, requires='0')
``` 

The requires field expects the step numbers to be comma separated as such:
* `0,2` requires the result of step 0 (initial value) and step 2