### PR TITLE
[feat] Dependency injection through the `requires` flag

### DIFF
--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -36,3 +36,27 @@ def test_process_requires():
         pass
     
     assert wf_iter.outputs[-1] == 'inputstep1step2inputinputstep1'
+
+def test_process_dependencies():
+    wf = Workflow('test_wf_1')\
+            .add(lambda x: x + 1)\
+            .add(lambda x, y: y, requires='d0')
+
+    wf_iter = wf(1, dependencies=['some_dep'])
+    for _ in wf_iter:
+        pass
+    
+    assert wf_iter.outputs[-1] == 'some_dep'
+
+def test_process_requires_with_dependencies():
+    """Test requires flags when previous outputs and dependencies are injected"""
+    wf = Workflow('test_wf_1')\
+            .add(lambda x: x[0])\
+            .add(lambda x, y, z: x + y + z, requires='0,d0')
+
+    wf_iter = wf('input', dependencies=['some_dep'])
+    for _ in wf_iter:
+        pass
+    
+    assert wf_iter.outputs[-1] == 'i' + 'input' + 'some_dep'
+


### PR DESCRIPTION
This PR will allow steps of workflows to depend on the dependencies passed when running the workflow. When a workflow needs dependencies in subsequent steps of its pipelines, propagating them would not only require rewriting the steps but it also makes it harder to debug what a single step is supposed to do.

The main change was the introduction of a dependencies attribute to the workflow iterator to save dependencies passed to it when running it.
```Python
wf_iter = workflow(input=some_input, dependencies=[])
```

This feature takes advantage of the `requires` flags landed with #11 to inject dependencies (prefixed with the letter `d` in the requires flag). 