### PR TITLE
Make Workflow iterator return the step name as well as the result

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ as it can work with both just fine.
 ### Workflows
 To add steps to a workflow, the class provides the `add` method which takes as input the function (process) and optionally
 an OutputHandler. The whole workflow will act as the `|` (pipe) operator in Unix terminals by successively feeding the output of a process as
-the input of the next process.
+the input of the next process. To run a workflow, you just need to iterate over it with the appropriate input(s).
 ```
 p1 -> p2 -> p3
 ```
@@ -42,7 +42,7 @@ In math terms, the workflow runs the function composition of all the steps.
 p3 \circ p2 \circ p1 (x)
 ```
 
-This shows how to define a simple workflow:
+This shows how to define and run a simple workflow:
 ```python
 from octopipes.workflow import Workflow
 
@@ -55,7 +55,7 @@ print(wf.nsteps)
 # `wf` will first run the input on the first function x ** 2, then run the second x - 4 with the result of the previous step.
 # So in the first step of the iteration the result will be 16 (4 ** 2) then 12 (16 - 4)
 wf_iter = wf(4)
-for result in wf_iter:
+for step, result in wf_iter:
     pass
 
 # return a frozen instance of the workflow run.

--- a/octopipes/workflow.py
+++ b/octopipes/workflow.py
@@ -86,7 +86,10 @@ class Workflow:
                 end = time.perf_counter()
                 self.outputs.append(self.current_output)
                 self.durations.append(end - start)
-                return self.current_output
+                step_name = self.workflow.processes[self.current_step - 1].__name__
+
+                return step_name, self.current_output
+
             raise StopIteration
 
         def _parse_requires(self, requires: str) -> list[Any]:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -7,7 +7,7 @@ def test_workflow():
             .add(lambda x: x)
     assert wf.nsteps == 2
     wf_iter = wf(1)
-    for result in wf_iter:
+    for _, result in wf_iter:
         assert result == 1
 
     wf_iter.recap()


### PR DESCRIPTION
This PR adds the possibility to return the name of the step while (running) iterating over the workflow. The current behavior to just return the output of a step, so although this is a breaking change it is minimal.

This is how it is done:
```Python
for result in wf(linput):
   pass
```

After pushing this PR, workflows are ran this way:
```Python
for step, result in wf(input):
    pass
```