### PR TITLE
AggregateFlows and Benchmarking support for workflows with dependencies

### DIFF
--- a/octopipes/dataset.py
+++ b/octopipes/dataset.py
@@ -54,3 +54,7 @@ class DataloaderIter:
         raise StopIteration
 
 
+@dataclass
+class InputWithDeps:
+    input: Any
+    dependencies: list

--- a/tests/test_aggregateflows.py
+++ b/tests/test_aggregateflows.py
@@ -9,7 +9,23 @@ def test_aggregateflows():
             .add(lambda x: x * 2)
     flows = AggregateFlows(2, workflows=[wf1, wf2])
     flows.run_workflows()
+
     assert len(flows.results) == 2
     assert flows.results[0].output == 3
     assert flows.results[1].output == 4
+
+
+def test_aggregateflows_with_dependencies():
+    wf1 = Workflow('test_wf_1')\
+            .add(lambda x, y: x + y, requires='d0')
+
+    wf2 = Workflow('test_wf_2')\
+            .add(lambda x, y: x - y, requires='d0')
+
+    flows = AggregateFlows(2, dependencies=[2], workflows=[wf1, wf2])
+    flows.run_workflows()
+
+    assert len(flows.results) == 2
+    assert flows.results[0].output == 4
+    assert flows.results[1].output == 0
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,5 +1,5 @@
 from octopipes.benchmark import Benchmark
-from octopipes.dataset import Dataloader, Dataset
+from octopipes.dataset import Dataloader, Dataset, InputWithDeps
 from octopipes.workflow import Workflow
 
 from tests.test_dataset import MockDataset
@@ -19,3 +19,36 @@ def test_benchmark():
     assert benchmark.results[0].results[1].output == 2
     assert benchmark.results[1].results[0].output == 3
     assert benchmark.results[1].results[1].output == 4
+
+
+def test_benchmark_with_dependencies():
+    wf1 = Workflow('test_wf_1')\
+            .add(lambda x, y: x + y, requires='d0')
+
+    wf2 = Workflow('test_wf_2')\
+            .add(lambda x, y: x - y, requires='d0')
+
+    # This dataset defines inputs with dependencies without ground truth
+    dataset: Dataset = MockDataset([InputWithDeps(2, dependencies=[2]), InputWithDeps(1, dependencies=[2])])
+    dataloader = Dataloader(dataset=dataset, batch_size=2, drop_last_batch=True)
+    benchmark = Benchmark(dataloader=dataloader, workflows=[wf1, wf2])
+    benchmark.run_tests()
+    assert len(benchmark.results) == 2
+    assert benchmark.results[0].results[0].output == 4
+    assert benchmark.results[0].results[1].output == 0
+    assert benchmark.results[1].results[0].output == 3
+    assert benchmark.results[1].results[1].output == -1
+
+    # this dataset defines inputs with dependencies with a ground truth value
+    dataset: Dataset = MockDataset([
+        (InputWithDeps(2, dependencies=[2]), 24),
+        (InputWithDeps(1, dependencies=[2]), 24)
+    ])
+    dataloader = Dataloader(dataset=dataset, batch_size=2, drop_last_batch=True)
+    benchmark = Benchmark(dataloader=dataloader, workflows=[wf1, wf2])
+    benchmark.run_tests()
+    assert len(benchmark.results) == 2
+    assert benchmark.results[0].results[0].output == 4
+    assert benchmark.results[0].results[1].output == 0
+    assert benchmark.results[1].results[0].output == 3
+    assert benchmark.results[1].results[1].output == -1


### PR DESCRIPTION
This PR makes it possible for the AggregateFlows class (and the benchmarking class) to play well with workflows that have additional dependencies (aka workflows with more than 1 input).

With these proposed changes, the `AggregateFlows` class can now accept an additional field `dependencies` that would be used (if not None) when running workflows, thus insuring that they have the correct inputs.
```Python
flows = AggregateFlows(input, dependencies=[x, y], workflows=[wf1, wf2])
```

To add support for the Benchmarking class, the only thing to add is to introduce the class `InputWithDeps`. When this type is used by the dataset (as the feature), the `DefaultAggregateFlowsFactory` would automatically "unpack" the object and inject the appropriate inputs to the AggregateFlows objects. Practically, we only need to define our dataset in particular way and `octopipes` takes care of the rest (of course when the `DefaultAggregateFlowsFactory` is used). 
Here's an example:
```Python
class Dataset:
    ....
    def __getitem__(self, index):
         ...
         return InputWithDeps(input=image, dependencies=[bboxes]), ground_truth
```

fixes #14 