### PR TITLE
JSON output improvements

### DIFF
--- a/octopipes/handlers.py
+++ b/octopipes/handlers.py
@@ -44,7 +44,7 @@ class SegmentationMasksHandler:
         return overlayed
 
     def to_json(self, output) -> str:
-        return json.dumps(output.tolist())
+        return json.dumps({'segmentation': output.tolist(), 'len_output': self.len_output(output)})
 
     def len_output(self, output: Any) -> int | None:
         return len(output)
@@ -69,7 +69,8 @@ class BboxesHandler:
             output = output.tolist()
         except AttributeError:
             pass
-        return json.dumps({'bboxes': [{'bbox': bbox} for bbox in output] if output is not None else None})
+        return json.dumps({'bboxes': [{'bbox': bbox} for bbox in output] if output is not None else None,
+                           'len_output': self.len_output(output)})
 
     def len_output(self, output: Any) -> int | None:
         return len(output)
@@ -102,7 +103,8 @@ class CmapBboxesHandler:
             output = output.tolist()
         except AttributeError:
             pass
-        return json.dumps({'bboxes': [{'bbox': bbox, 'val': val} for bbox, val in output] if output is not None else None})
+        return json.dumps({'bboxes': [{'bbox': bbox, 'val': val} for bbox, val in output] if output is not None else None,
+                           'len_output': self.len_output(output)})
 
     def len_output(self, output: Any) -> int | None:
         return len(output)
@@ -129,7 +131,7 @@ class CirclesHandler:
             output = output.tolist()
         except AttributeError:
             pass
-        return json.dumps({'circles': output})
+        return json.dumps({'circles': output, 'len_output': self.len_output(output)})
 
     def len_output(self, output: Any) -> int | None:
         return len(output)

--- a/octopipes/handlers.py
+++ b/octopipes/handlers.py
@@ -23,7 +23,7 @@ class DefaultHandler:
         return image
 
     def len_output(self, output: Any) -> int | None:
-        return len(output)
+        return len(output) if output is not None else 0
 
     def to_json(self, output: Any) -> str:
         return json.dumps(output)
@@ -47,7 +47,7 @@ class SegmentationMasksHandler:
         return json.dumps({'segmentation': output.tolist(), 'len_output': self.len_output(output)})
 
     def len_output(self, output: Any) -> int | None:
-        return len(output)
+        return len(output) if output is not None else 0
 
 
 class BboxesHandler:
@@ -73,7 +73,7 @@ class BboxesHandler:
                            'len_output': self.len_output(output)})
 
     def len_output(self, output: Any) -> int | None:
-        return len(output)
+        return len(output) if output is not None else 0
 
 
 class CmapBboxesHandler:
@@ -107,7 +107,7 @@ class CmapBboxesHandler:
                            'len_output': self.len_output(output)})
 
     def len_output(self, output: Any) -> int | None:
-        return len(output)
+        return len(output) if output is not None else 0
 
 
 class CirclesHandler:
@@ -134,5 +134,5 @@ class CirclesHandler:
         return json.dumps({'circles': output, 'len_output': self.len_output(output)})
 
     def len_output(self, output: Any) -> int | None:
-        return len(output)
+        return len(output) if output is not None else 0
 

--- a/octopipes/results.py
+++ b/octopipes/results.py
@@ -21,3 +21,4 @@ class Results(BaseModel):
     len_output: int | None
     total_duration: float
     output_recap: tuple[Step, ...]
+    json_output: str

--- a/octopipes/workflow.py
+++ b/octopipes/workflow.py
@@ -175,4 +175,5 @@ class Workflow:
                            output=self.current_output,
                            len_output=self.len_output(),
                            total_duration=self.total_duration,
-                           output_recap=self.steps_recap())
+                           output_recap=self.steps_recap(),
+                           json_output=self.json_output())

--- a/octopipes/workflow.py
+++ b/octopipes/workflow.py
@@ -145,6 +145,13 @@ class Workflow:
                 cv2.waitKey(0)
                 cv2.destroyAllWindows()
 
+        def json_output(self, output: int = -1) -> str:
+            """Returns the json output of a step using the corresponding handler"""
+            handler = self.workflow.handlers[output]
+            output = self.outputs[output]
+
+            return handler.to_json(output)
+
         def steps_recap(self) -> tuple[Step, ...]:
             return tuple({'step': process.__name__, 'duration': d} for process, d in zip(self.workflow.processes, self.durations))
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -19,12 +19,12 @@ def test_BboxHandler():
     assert handler.len_output(test_list) == 2
     assert handler.len_output(test_array) == 2
 
-    assert handler.to_json([[0, 0, 10, 10]]) == '{"bboxes": [{"bbox": [0, 0, 10, 10]}]}'
-    assert handler.to_json(np.array([[0, 0, 10, 10]])) == '{"bboxes": [{"bbox": [0, 0, 10, 10]}]}'
-    assert handler.to_json([[]]) == '{"bboxes": [{"bbox": []}]}'
-    assert handler.to_json(np.array([[]])) == '{"bboxes": [{"bbox": []}]}'
-    assert handler.to_json(np.array([])) == '{"bboxes": []}'
-    assert handler.to_json(None) == '{"bboxes": null}'
+    assert handler.to_json([[0, 0, 10, 10]]) == '{"bboxes": [{"bbox": [0, 0, 10, 10]}], "len_output": 1}'
+    assert handler.to_json(np.array([[0, 0, 10, 10]])) == '{"bboxes": [{"bbox": [0, 0, 10, 10]}], "len_output": 1}'
+    assert handler.to_json([[]]) == '{"bboxes": [{"bbox": []}], "len_output": 1}'
+    assert handler.to_json(np.array([[]])) == '{"bboxes": [{"bbox": []}], "len_output": 1}'
+    assert handler.to_json(np.array([])) == '{"bboxes": [], "len_output": 0}'
+    assert handler.to_json(None) == '{"bboxes": null, "len_output": 0}'
 
 
 def test_CirclesHandler():
@@ -35,10 +35,10 @@ def test_CirclesHandler():
     assert handler.len_output(test_list) == 2
     assert handler.len_output(test_array) == 2
 
-    assert handler.to_json(test_list) == '{"circles": [[0, 0, 10], [10, 7, 5]]}'
-    assert handler.to_json(test_array) == '{"circles": [[0, 0, 10], [10, 7, 5]]}'
-    assert handler.to_json([]) == '{"circles": []}'
-    assert handler.to_json(None) == '{"circles": null}'
+    assert handler.to_json(test_list) == '{"circles": [[0, 0, 10], [10, 7, 5]], "len_output": 2}'
+    assert handler.to_json(test_array) == '{"circles": [[0, 0, 10], [10, 7, 5]], "len_output": 2}'
+    assert handler.to_json([]) == '{"circles": [], "len_output": 0}'
+    assert handler.to_json(None) == '{"circles": null, "len_output": 0}'
 
 
 def test_CmapBboxesHandler():
@@ -47,7 +47,7 @@ def test_CmapBboxesHandler():
 
     assert handler.len_output(test_list) == 2
 
-    assert handler.to_json(test_list) == '{"bboxes": [{"bbox": [0, 0, 10, 10], "val": 1}, {"bbox": [0, 0, 10, 10], "val": 2}]}'
-    assert handler.to_json([]) == '{"bboxes": []}'
-    assert handler.to_json(None) == '{"bboxes": null}'
+    assert handler.to_json(test_list) == '{"bboxes": [{"bbox": [0, 0, 10, 10], "val": 1}, {"bbox": [0, 0, 10, 10], "val": 2}], "len_output": 2}'
+    assert handler.to_json([]) == '{"bboxes": [], "len_output": 0}'
+    assert handler.to_json(None) == '{"bboxes": null, "len_output": 0}'
 


### PR DESCRIPTION
This PR adds a `len_output` key in the json object returned by output handlers. As well as implement the features needed for #16

When this PR lands, the json output string can be accessed directly from the WorkflowIter class as well as the Result class.

```Python
wf_iter.json_output(output=2) # access the json output of the 3 third step of the workflow
```

closes #16 