### PR TITLE
Fix overflow issue in circles to bboxes

### DIFF
--- a/octopipes/process.py
+++ b/octopipes/process.py
@@ -1,5 +1,5 @@
 """General useful set of processes"""
 
 def circles_to_bboxes(circles) -> list:
-    return [(int(x - r), int(y + r), int(x + r), int(y - r))
-                for x, y, r in circles]
+    return [(int(x) - int(r), int(y) - int(r), int(x) + int(r), int(y) + int(r)) 
+            for x, y, r in circles]


### PR DESCRIPTION
### Description:
The circles_to_bboxes function in the octopipes.process module was returning bounding boxes in the incorrect format: [X_min, Y_max, X_max, Y_min] instead of the standard [X_min, Y_min, X_max, Y_max]. This format was not intuitive and was causing confusion. Additionally, there was an overflow issue in the conversion process.

### Solution:
The function has been updated to correctly convert the circles into the standard bounding box format [X_min, Y_min, X_max, Y_max]. The overflow issue was addressed by ensuring that the inputs to the conversion process are handled properly.