### PR TITLE
Fix circle handler 'color' is not numeric

### DIFF
--- a/octopipes/handlers.py
+++ b/octopipes/handlers.py
@@ -121,7 +121,7 @@ class CirclesHandler:
             return image
 
         for x, y, r in output:
-            color = list(np.random.choice(range(256), size=3))
+            color = tuple(map(int, np.random.choice(range(256), size=3)))
             cv2.circle(image, (int(x), int(y)), int(r), color, 3)
         return image
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -40,6 +40,10 @@ def test_CirclesHandler():
     assert handler.to_json([]) == '{"circles": [], "len_output": 0}'
     assert handler.to_json(None) == '{"circles": null, "len_output": 0}'
 
+    img = np.random.rand(100,100,3) * 255
+
+    handler.output_on_image(img, test_list)
+
 
 def test_CmapBboxesHandler():
     handler = CmapBboxesHandler()


### PR DESCRIPTION
This PR fixes issue #23. opencv expects the colors to be int but they had a numpy integer type.