### PR TITLE
fixed len_output method does not support handler-defined logic issue

### DIFF
--- a/octopipes/handlers.py
+++ b/octopipes/handlers.py
@@ -23,7 +23,9 @@ class DefaultHandler:
         return image
 
     def len_output(self, output: Any) -> int | None:
-        return len(output) if output is not None else 0
+        if output is not None and hasattr(output, '__len__'):
+            return len(output)
+        return 0
 
     def to_json(self, output: Any) -> str:
         return json.dumps(output)
@@ -73,7 +75,9 @@ class BboxesHandler:
                            'len_output': self.len_output(output)})
 
     def len_output(self, output: Any) -> int | None:
-        return len(output) if output is not None else 0
+        if output is not None and hasattr(output, '__len__'):
+            return len(output)
+        return 0
 
 
 class CmapBboxesHandler:
@@ -107,7 +111,9 @@ class CmapBboxesHandler:
                            'len_output': self.len_output(output)})
 
     def len_output(self, output: Any) -> int | None:
-        return len(output) if output is not None else 0
+        if output is not None and hasattr(output, '__len__'):
+            return len(output)
+        return 0
 
 
 class CirclesHandler:
@@ -134,5 +140,7 @@ class CirclesHandler:
         return json.dumps({'circles': output, 'len_output': self.len_output(output)})
 
     def len_output(self, output: Any) -> int | None:
-        return len(output) if output is not None else 0
+        if output is not None and hasattr(output, '__len__'):
+            return len(output)
+        return 0
 

--- a/octopipes/workflow.py
+++ b/octopipes/workflow.py
@@ -170,7 +170,7 @@ class Workflow:
             handler = self.workflow.handlers[output]
             output = self.outputs[output]
 
-            return handler.len_output(output) if hasattr(output, '__len__') else None
+            return handler.len_output(output) 
 
         def freeze(self) -> Results:
             return Results(name=self.workflow.name,

--- a/octopipes/workflow.py
+++ b/octopipes/workflow.py
@@ -165,8 +165,12 @@ class Workflow:
         def final_output(self):
             return self.outputs[-1]
 
-        def len_output(self):
-            return len(self.current_output) if hasattr(self.current_output, '__len__') else None
+        def len_output(self, output: int = -1) -> int | None:
+            """Returns the length of the output of a step using the corresponding handler"""
+            handler = self.workflow.handlers[output]
+            output = self.outputs[output]
+
+            return handler.len_output(output) if hasattr(output, '__len__') else None
 
         def freeze(self) -> Results:
             return Results(name=self.workflow.name,


### PR DESCRIPTION
This pull request refactors the len_output method in the workflow implementation to address inconsistencies in how output lengths are calculated. Previously, the method directly computed the length of self.current_output, ignoring handler-defined logic. This caused issues when custom handlers redefined the logic for determining output length.

The updated implementation now leverages the corresponding handler to calculate the length of the output, ensuring consistency across workflows.

**Key Changes:**

**1.Delegation to Handlers**:
- The method now retrieves the appropriate handler using self.workflow.handlers and delegates the length calculation to handler.len_output(output).

**2.Flexible Output Selection**:
- Added an output parameter (default: -1) to specify which output to evaluate, making the method more versatile for workflows with multiple outputs.

**3.Improved Readability and Maintenance**:
- Introduced type hints (int | None) and a detailed docstring for better code clarity and usability.